### PR TITLE
Use HTTPS to fetch MPCM layer catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ either local to the current project, or globally for your whole system.
 
 To install the command globally, so it can be used from any project in our system, use this command:
 
-    npm install -global @bcgov/smk-cli
+    npm install --global @bcgov/smk-cli
 
 This may require you to use administrative rights (or `sudo`) on your machine, depending on how it is configured.
 
@@ -53,4 +53,4 @@ For more information on the SMK project, or to read documentation on SMK develop
 
 # Uninstall
 
-    npm uninstall —global @bcgov/smk-cli
+    npm uninstall --global @bcgov/smk-cli

--- a/build/test-app/index.html
+++ b/build/test-app/index.html
@@ -15,7 +15,7 @@
 
         <footer>Application constructed by smk-cli at 2020-07-23T19:18:25.876Z</footer>
 
-        <script src="./node_modules/@qqnluaq/smk/dist/smk.js"></script>
+        <script src="./node_modules/@bcgov/smk/dist/smk.js"></script>
         <script src="./smk-init.js"></script>
     </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/smk-cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A utility for creating and configuring a Simple Map Kit project",
   "main": "index.js",
   "author": "Ben Jubb <benjubb@gmail.com>",
@@ -16,6 +16,7 @@
     "debug": "./index.js edit --open no --base build/test-app --ping 300000"
   },
   "dependencies": {
+    "@bcgov/smk": "^1.0.2",
     "@tmcw/togeojson": "^4.1.0",
     "chalk": "^4.1.0",
     "cors": "^2.8.5",
@@ -35,7 +36,6 @@
     "semver": "^7.3.2",
     "shapefile": "^0.6.6",
     "shelljs": "^0.8.4",
-    "@bcgov/smk": "^1.0.2",
     "touch": "^3.1.0",
     "unzipper": "^0.10.11",
     "xml2js": "^0.4.23",

--- a/smk-edit/controllers/catalogs.js
+++ b/smk-edit/controllers/catalogs.js
@@ -1,5 +1,5 @@
 const xml2js = require( 'xml2js' ).parseString
-const http = require( 'http' )
+const https = require( 'https' )
 const layer = require( './layer.js' )
 const path = require( 'path' )
 const fs = require( 'fs' )
@@ -12,7 +12,6 @@ const DATABC_SERVICE_URL = 'https://maps.gov.bc.ca/arcgis/rest/services/mpcm/bcg
 
 const MPCM_OPTIONS = {
     host: 'apps.gov.bc.ca',
-    port: '80',
     path: 'https://apps.gov.bc.ca/pub/mpcm/services/catalog/PROD',
     method: 'GET',
     headers: {
@@ -68,7 +67,7 @@ function getMpcmCatalog( req, res, next ) {
     }
 
     console.log( '    Loading MPCM Catalog from ' + MPCM_OPTIONS.path )
-    var mpcmReq = http.request( MPCM_OPTIONS, function( resp ) {
+    var mpcmReq = https.request( MPCM_OPTIONS, function( resp ) {
         resp.setEncoding('utf8');
 
         var msg = ''
@@ -111,7 +110,7 @@ function getMpcmCatalogLayerConfig( req, res, next ) {
     options.path += '/' + mpcmId;
 
     console.log( '    Loading MPCM Layer from ' + options.path )
-    var mpcmReq = http.request( options, function ( resp ) {
+    var mpcmReq = https.request( options, function ( resp ) {
         resp.setEncoding('utf8');
 
         var msg = '';


### PR DESCRIPTION
- Use https module to make requests to the MCPM catalog
- Fix typos in README: -global -> --global
- Alphabetize dependencies in package.json
- Test app should reference smk package in the @bcgov scope
- Increment version in preparation for publishing npm package

#### Testing
1. Clone the repo and check out this branch
2. Open a command prompt and navigate to the root directory
3. npm install
4. Run  'node ./index.js create' to start up the smk-cli interface and create a new map app
5. Hit 'Enter' at each prompt to accept all defaults (9 times in total)
6. When prompted to edit the application, enter 'y'
7. A browser window will open with the SMK editor UI.
8. In the left panel click 'Layers' and then click 'Manage DataBC Layers'
9. You should a list of all the layers available from MPCM. This would previously fail because the catalog layers were being requested via HTTP instead of HTTPS.