### PR TITLE
Fixing figlet font issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,8 +20,10 @@ const fonts = [
     'shadow', 'small', 'speed', 'sl script', 'stop', 'swan', 'soft'
 ]
 const ver = 'CLI v' + package.version
+var fontName = fonts[ Math.round( fonts.length * Math.random() ) ];
+fontName = fontName.charAt(0).toUpperCase() + fontName.slice(1);
 const title = figlet.textSync( 'Simple Map Kit', {
-    font: fonts[ Math.round( fonts.length * Math.random() ) ],
+    font: fontName,
     horizontalLayout: 'full'
 } ).slice( 0, -ver.length )
 console.log( chalk.yellow( title ) + chalk.gray( ver ) )


### PR DESCRIPTION
Figlet installs fonts with capitalized font names, example `Soft.flf`.  Line 18 defines a subset of the fonts to choose from.  The font names cases however are not capitalized.  The result is on case sensitive file systems the os will not be able to find the fonts that are being referred to.