### PR TITLE
No error attempting to load catalog in empty layers directory

### DIFF
--- a/smk-edit/controllers/catalogs.js
+++ b/smk-edit/controllers/catalogs.js
@@ -307,7 +307,13 @@ function getWmsCatalogLayerConfig( req, res, next ) {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 function getLocalCatalog( req, res, next ) {
-    var catalogFile = path.resolve( req.app.get( 'layers' ), '-smk-catalog.json' )
+    var layersDir = req.app.get( 'layers' )
+    var catalogFile = path.resolve( layersDir, '-smk-catalog.json' )
+
+    if ( fs.readdirSync(layersDir).length === 0 ) {
+        console.log( `    Layers directory ${ layersDir } is empty; skipping read of catalog` )
+        return
+    }
 
     if ( !fs.existsSync( catalogFile ) ) {
         console.log( `    No catalog at ${ catalogFile }` );


### PR DESCRIPTION
When a user navigates to Layers/Manage Vector Layers and the layers
catalog is missing, a "No catalog at ..." error is displayed and logged.
However, if no layers have been imported, no catalog will have been
created, and this error is inappropriate.

This change updates catalogs.js functionality for getting the local
catalog. When the layers directory is empty, we no longer give an error,
and we log a message saying that the layers directory is empty and we
are skipping getting the local catalog.