### PR TITLE
Layer upload status is better displayed

### DIFF
--- a/docs/edit-layer.md
+++ b/docs/edit-layer.md
@@ -182,7 +182,7 @@ If you wish to apply other style types to a vector (for instance, using markers 
 
 Marker styles require a marker image, a Marker size, and a marker offset.
 
-To add a marker image to your application, click once on the `Upload` button. This will open your operating systems standard file selection dialog. Select a file to import it into your application. Once imported, your marker image will be available to select in the `Marker URL` dropdown selection box.
+To add a marker image to your application, click once on the `Upload` button. This will open your operating system's standard file selection dialog. Select a file to import it into your application. Once imported, your marker image will be available to select in the `Marker URL` dropdown selection box.
 
 `Marker Size` allows you to specify the size of the image in pixels as it will display on the map. Images that are larger then the specified size will shrink to match, smaller images will be stretched.
 

--- a/smk-edit/static/components/tab-vector-layers.html
+++ b/smk-edit/static/components/tab-vector-layers.html
@@ -33,26 +33,12 @@
                                         Upload
                                         <input type="file" style="display:none"
                                             ref="fileInput"
-                                            v-on:change="readFile( $event )"
+                                            v-on:change="readFileAndImportLayer( $event )"
                                             v-bind:accept="acceptFileTypes"
                                         />
                                     </label>
                                 </div>
                             </form>
-                        </div>
-
-                        <div class="row tight">
-                            <input-textarea class="col s6"
-                                v-model="importTitle"
-                                v-bind:disabled="!importFile"
-                            >Title</input-textarea>
-
-                            <div class="col s6 right-align">
-                                <a class="waves-effect waves-light btn blue-grey darken-2" style="margin-top: 25px"
-                                    v-on:click="importLayer"
-                                    v-bind:class="{ disabled: !importFile }"
-                                ><i class="material-icons right">library_add</i>Import Layer</a>
-                            </div>
                         </div>
                     </div>
                 </li>

--- a/smk-edit/static/components/tab-vector-layers.html
+++ b/smk-edit/static/components/tab-vector-layers.html
@@ -41,12 +41,6 @@
                             </form>
                         </div>
 
-                        <div style="position: relative;">
-                            <div class="grey-text" style="position: absolute; top: -20px; padding: 0 0.75rem;"
-                                v-if="importFilename()"
-                            >Uploaded <pre style="font-size:smaller; display: inline">{{ importFilename() }}</pre></div>
-                        </div>
-
                         <div class="row tight">
                             <input-textarea class="col s6"
                                 v-model="importTitle"

--- a/smk-edit/static/components/tab-vector-layers.js
+++ b/smk-edit/static/components/tab-vector-layers.js
@@ -35,7 +35,9 @@ export default importComponents( [
             },
         },
         methods: {
-            readFile: function ( ev ) {
+            readFileAndImportLayer: function ( ev ) {
+                var self = this
+
                 this.importTitle = null
                 this.importFile = false
 
@@ -46,10 +48,6 @@ export default importComponents( [
 
                 var m = this.$vectorFile.name.match( /(^|[/\\])([^/\\.]+)[.](.+)$/ )
                 this.importTitle = m ? m[ 2 ] : this.$vectorFile.name
-                M.toast( { html: 'Uploaded ' + this.importTitle } )
-            },
-            importLayer: function () {
-                var self = this
 
                 var formData = new FormData()
                 formData.append( 'file', this.$vectorFile )

--- a/smk-edit/static/components/tab-vector-layers.js
+++ b/smk-edit/static/components/tab-vector-layers.js
@@ -128,6 +128,7 @@ export default importComponents( [
 
             },
             closeImportOptions: function ( ok ) {
+                if ( !ok ) this.resetImport()
                 this.showImportOptions = false
                 if ( !this.continueImportOptions ) return
 

--- a/smk-edit/static/components/tab-vector-layers.js
+++ b/smk-edit/static/components/tab-vector-layers.js
@@ -46,10 +46,7 @@ export default importComponents( [
 
                 var m = this.$vectorFile.name.match( /(^|[/\\])([^/\\.]+)[.](.+)$/ )
                 this.importTitle = m ? m[ 2 ] : this.$vectorFile.name
-            },
-            importFilename: function () {
-                if ( !this.$vectorFile ) return
-                return this.$vectorFile.name
+                M.toast( { html: 'Uploaded ' + this.importTitle } )
             },
             importLayer: function () {
                 var self = this


### PR DESCRIPTION
When a vector dataset file is uploaded, an "Uploaded" message is displayed as text in an awkward location in between two other components. This change displays the text differently by putting it into a "toast" alert box, a technique that is often used elsewhere in the application to display status messages. This also makes a small correction in layer documentation.