### PR TITLE
Fixed case of fonts in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,8 +16,8 @@ opt.isGlobal = isGlobal
 opt.exec = exec
 
 const fonts = [
-    'big', 'doom', 'graffiti', 'rectangles', 'gothic', 'script',
-    'shadow', 'small', 'speed', 'sl script', 'stop', 'swan', 'soft'
+    'Big', 'Doom', 'Gothic', 'Graffiti', 'Rectangles', 'Script',
+    'Shadow', 'SL Script', 'Small', 'Soft', 'Speed', 'Stop', 'Swan'
 ]
 const ver = 'CLI v' + package.version
 const title = figlet.textSync( 'Simple Map Kit', {


### PR DESCRIPTION
When smk-cli is installed onto an operating system having a case sensitive filesystem, we see "no such file" errors when running commands like "smk help". This is because the font names used in index.js do not match the case of the names of the font files.

This change updates index.js to apply the correct case to fonts so that they match the names of font files.