### PR TITLE
Can set showCoverageOnHover for vector layer

### DIFF
--- a/docs/edit-layer.md
+++ b/docs/edit-layer.md
@@ -104,7 +104,7 @@ From the WMS Details panel, you can modify the following attributes:
 
 #### Metadata URL
 
-`Metadata URL` is a supplied URL for the layers metadata. By default this is empty for WMS layers, but can be supplied if desired. This is useful for providing users with links to data sources or specific external resources related to the data displayed in your application.
+`Metadata URL` is a supplied URL for the layer's metadata. By default this is empty for WMS layers, but can be supplied if desired. This is useful for providing users with links to data sources or specific external resources related to the data displayed in your application.
 
 ### Vector Layer Details
 
@@ -133,7 +133,7 @@ Note that the Vector Details panel is the same if you've imported vector data di
 
 #### Opacity
 
-`Opacity` adjusts how transparent the layer is by default. Making a layer 100% Opaque will prevent users from seeing feaures covered by this layer. Setting a layer to 0% Opaque will prevent it from displaying on the map at all, but it will still be identifiable and selectable (just invisible).
+`Opacity` adjusts how transparent the layer is by default. Making a layer 100% opaque will prevent users from seeing features covered by this layer. Setting a layer to 0% opaque will prevent it from displaying on the map at all, but it will still be identifiable and selectable (just invisible).
 
 #### Display Range
 
@@ -161,11 +161,11 @@ Note that the Vector Details panel is the same if you've imported vector data di
 
 #### Data URL
 
-`Data URL` is the URL location for your vector data. If you've imported a vector file into your application, this will be a local path to your applications source folder. Do not modify this URL unless you are sure you want to direct the application to search a specific location for the vector data.
+`Data URL` is the URL location for your vector data. If you've imported a vector file into your application, this will be a local path to your application's source folder. Do not modify this URL unless you are sure you want to direct the application to search a specific location for the vector data.
 
 #### Metadata URL
 
-`Metadata URL` is a supplied URL for the layers metadata. By default this is empty for WMS layers, but can be supplied if desired. This is useful for providing users with links to data sources or specific external resources related to the data displayed in your application.
+`Metadata URL` is a supplied URL for the layer's metadata. By default this is empty for WMS layers, but can be supplied if desired. This is useful for providing users with links to data sources or specific external resources related to the data displayed in your application.
 
 ### Vector Styling
 

--- a/docs/edit-layer.md
+++ b/docs/edit-layer.md
@@ -116,9 +116,9 @@ From the Vector Details panel, you can modify the following attributes:
 - Available for Identify
 - Opacity
 - Display Range
+- Data URL
 - How should the Data be Displayed?
 - Show Cluster Bounds on Hover 
-- Data URL
 - Metadata URL
 
 Note that the Vector Details panel is the same if you've imported vector data directly into your application, or if you're using a URL.
@@ -139,6 +139,10 @@ Note that the Vector Details panel is the same if you've imported vector data di
 
 `Display Range` allows you to specify an allowable range where this layer can be displayed. If your map is outside of this scale range, the layer will not draw on the map, and will not be identifiable or selectable.
 
+#### Data URL
+
+`Data URL` is the URL location for your vector data. If you've imported a vector file into your application, this will be a local path to your application's source folder. Do not modify this URL unless you are sure you want to direct the application to search a specific location for the vector data.
+
 #### How should the Data be Displayed
 
 `How should the Data be Displayed?` is a styling override for your vector data. This is a dropdown select box that contains three options:
@@ -158,10 +162,6 @@ Note that the Vector Details panel is the same if you've imported vector data di
 `Show Cluster Bounds on Hover` shows the bounds of a cluster's markers when you mouse over the cluster.  
 
 > __Note:__ This option only appears when `Show Features in Clusters` is selected for `How should the Data be Displayed?`.
-
-#### Data URL
-
-`Data URL` is the URL location for your vector data. If you've imported a vector file into your application, this will be a local path to your application's source folder. Do not modify this URL unless you are sure you want to direct the application to search a specific location for the vector data.
 
 #### Metadata URL
 

--- a/docs/edit-layer.md
+++ b/docs/edit-layer.md
@@ -84,7 +84,7 @@ From the WMS Details panel, you can modify the following attributes:
 
 #### Opacity
 
-`Opacity` adjust how transparent the layer is by default. Making a layer 100% Opaque will prevent users from seeing feaures covered by this layer. Setting a layer to 0% Opaque will prevent it from displaying on the map at all, but it will still be identifiable and selectable (just invisible).
+`Opacity` adjusts how transparent the layer is by default. Making a layer 100% Opaque will prevent users from seeing feaures covered by this layer. Setting a layer to 0% Opaque will prevent it from displaying on the map at all, but it will still be identifiable and selectable (just invisible).
 
 #### Display Range
 
@@ -100,11 +100,11 @@ From the WMS Details panel, you can modify the following attributes:
 
 #### Style Name
 
-`Style Name` Is the name of the WMS Service layer style you are presenting to your users. This should not be modified unless you are certain of a change to source layer styles (confirmed by a review of the WMS Service GetCapabilities). Usually, it's easier to simply re-add the layer.
+`Style Name` is the name of the WMS Service layer style you are presenting to your users. This should not be modified unless you are certain of a change to source layer styles (confirmed by a review of the WMS Service GetCapabilities). Usually, it's easier to simply re-add the layer.
 
 #### Metadata URL
 
-`Metadata URL` is A supplied URL for the layers metadata. By default this is empty for WMS layers, but can be supplied if desired. This is useful for providing users with links to data sources or specific external resources related to the data displayed in your application.
+`Metadata URL` is a supplied URL for the layers metadata. By default this is empty for WMS layers, but can be supplied if desired. This is useful for providing users with links to data sources or specific external resources related to the data displayed in your application.
 
 ### Vector Layer Details
 
@@ -116,8 +116,9 @@ From the Vector Details panel, you can modify the following attributes:
 - Available for Identify
 - Opacity
 - Display Range
-- Data URL
 - How should the Data be Displayed?
+- Show Cluster Bounds on Hover 
+- Data URL
 - Metadata URL
 
 Note that the Vector Details panel is the same if you've imported vector data directly into your application, or if you're using a URL.
@@ -132,19 +133,15 @@ Note that the Vector Details panel is the same if you've imported vector data di
 
 #### Opacity
 
-`Opacity` adjust how transparent the layer is by default. Making a layer 100% Opaque will prevent users from seeing feaures covered by this layer. Setting a layer to 0% Opaque will prevent it from displaying on the map at all, but it will still be identifiable and selectable (just invisible).
+`Opacity` adjusts how transparent the layer is by default. Making a layer 100% Opaque will prevent users from seeing feaures covered by this layer. Setting a layer to 0% Opaque will prevent it from displaying on the map at all, but it will still be identifiable and selectable (just invisible).
 
 #### Display Range
 
 `Display Range` allows you to specify an allowable range where this layer can be displayed. If your map is outside of this scale range, the layer will not draw on the map, and will not be identifiable or selectable.
 
-#### Data URL
-
-`Data URL` Is the URL location for your vector data. If you've imported a vector file into your application, this will be a local path to your applications source folder. Do not modify this URL unless you are sure you want to direct the application to search a specific location for the vector data.
-
 #### How should the Data be Displayed
 
-`How should the Data be Displayed?` Is a styling override for your vector data. This is a dropdown select box that contains three options:
+`How should the Data be Displayed?` is a styling override for your vector data. This is a dropdown select box that contains three options:
 
 - Show Feature as Styled (Default)
 - Show Features in Clusters
@@ -152,13 +149,23 @@ Note that the Vector Details panel is the same if you've imported vector data di
 
 `Show Feature as Styled` will use the supplied vector styling for the layer. This is the default setting for vector layers.
 
-`Show Features in Clusters` Will still use your default layer styling, but it will show the features clustered on the map, expanding them as you zoom in. This is very useful for dense sets of vector point data.
+`Show Features in Clusters` will still use your default layer styling, but it will show the features clustered on the map, expanding them as you zoom in. This is very useful for dense sets of vector point data.
 
-`Show Features as a Heatmap` Will remove your default styling and convert the data into a heatmap display. This is very useful for point data sets.
+`Show Features as a Heatmap` will remove your default styling and convert the data into a heatmap display. This is very useful for point data sets.
+
+#### Show Cluster Bounds on Hover 
+
+`Show Cluster Bounds on Hover` shows the bounds of a cluster's markers when you mouse over the cluster.  
+
+> __Note:__ This option only appears when `Show Features in Clusters` is selected for `How should the Data be Displayed?`.
+
+#### Data URL
+
+`Data URL` is the URL location for your vector data. If you've imported a vector file into your application, this will be a local path to your applications source folder. Do not modify this URL unless you are sure you want to direct the application to search a specific location for the vector data.
 
 #### Metadata URL
 
-`Metadata URL` is A supplied URL for the layers metadata. By default this is empty for WMS layers, but can be supplied if desired. This is useful for providing users with links to data sources or specific external resources related to the data displayed in your application.
+`Metadata URL` is a supplied URL for the layers metadata. By default this is empty for WMS layers, but can be supplied if desired. This is useful for providing users with links to data sources or specific external resources related to the data displayed in your application.
 
 ### Vector Styling
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.1",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
-        "@bcgov/smk": "^1.0.2",
+        "@bcgov/smk": ">=1.0.6",
         "@tmcw/togeojson": "^4.1.0",
         "chalk": "^4.1.0",
         "cors": "^2.8.5",
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@bcgov/smk": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@bcgov/smk/-/smk-1.0.5.tgz",
-      "integrity": "sha512-USxTYj1kGRP0L29meTs+gDWmQZUUY3p1lZI6SPe1L2ftjRTRBKtD2OUwfoC94CxLDQIoiVvpY2Ee5jUjKKOtdA=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@bcgov/smk/-/smk-1.0.6.tgz",
+      "integrity": "sha512-+KDt6AouL7cOvJloSg4nPnwMXlLzE9A+GmJx2/ieG2XaHEQ2XmmtcOyDW0sRVYR/kgc/JeBp9XH+Uo7VztyvJg=="
     },
     "node_modules/@tmcw/togeojson": {
       "version": "4.5.0",
@@ -3072,9 +3072,9 @@
   },
   "dependencies": {
     "@bcgov/smk": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@bcgov/smk/-/smk-1.0.5.tgz",
-      "integrity": "sha512-USxTYj1kGRP0L29meTs+gDWmQZUUY3p1lZI6SPe1L2ftjRTRBKtD2OUwfoC94CxLDQIoiVvpY2Ee5jUjKKOtdA=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@bcgov/smk/-/smk-1.0.6.tgz",
+      "integrity": "sha512-+KDt6AouL7cOvJloSg4nPnwMXlLzE9A+GmJx2/ieG2XaHEQ2XmmtcOyDW0sRVYR/kgc/JeBp9XH+Uo7VztyvJg=="
     },
     "@tmcw/togeojson": {
       "version": "4.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bcgov/smk-cli",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bcgov/smk-cli",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@bcgov/smk": ">=1.0.6",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "debug": "./index.js edit --open no --base build/test-app --ping 300000"
   },
   "dependencies": {
-    "@bcgov/smk": "^1.0.2",
+    "@bcgov/smk": ">=1.0.6",
     "@tmcw/togeojson": "^4.1.0",
     "chalk": "^4.1.0",
     "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/smk-cli",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A utility for creating and configuring a Simple Map Kit project",
   "main": "index.js",
   "author": "Ben Jubb <benjubb@gmail.com>",

--- a/smk-edit/static/components/edit-item-details-layer-vector.html
+++ b/smk-edit/static/components/edit-item-details-layer-vector.html
@@ -1,11 +1,5 @@
 <div>
     <div class="row">
-        <input-textarea class="col s12"
-            v-model="dataUrl"
-        >Data URL</input-textarea>
-    </div>
-
-    <div class="row">
         <input-select class="col s12"
             v-model="displayMode"
         >How should the data be displayed?
@@ -15,5 +9,17 @@
                 <option value="heatmap">Show features as a heatmap</option>
             </template>
         </input-select>
+    </div>
+
+    <div class="row">
+        <input-checkbox v-if="displayMode === 'cluster'" class="col s12"
+            v-model="showCoverageOnHover"
+        >Show the bounds of a cluster on hover</input-checkbox>
+    </div>
+
+    <div class="row">
+        <input-textarea class="col s12"
+            v-model="dataUrl"
+        >Data URL</input-textarea>
     </div>
 </div>

--- a/smk-edit/static/components/edit-item-details-layer-vector.html
+++ b/smk-edit/static/components/edit-item-details-layer-vector.html
@@ -1,5 +1,11 @@
 <div>
     <div class="row">
+        <input-textarea class="col s12"
+            v-model="dataUrl"
+        >Data URL</input-textarea>
+    </div>
+
+    <div class="row">
         <input-select class="col s12"
             v-model="displayMode"
         >How should the data be displayed?
@@ -11,15 +17,9 @@
         </input-select>
     </div>
 
-    <div class="row">
+    <div class="row" v-bind:style="{position:'relative'}">
         <input-checkbox v-if="displayMode === 'cluster'" class="col s12"
             v-model="showCoverageOnHover"
         >Show the bounds of a cluster on hover</input-checkbox>
-    </div>
-
-    <div class="row">
-        <input-textarea class="col s12"
-            v-model="dataUrl"
-        >Data URL</input-textarea>
     </div>
 </div>

--- a/smk-edit/static/components/edit-item-details-layer-vector.js
+++ b/smk-edit/static/components/edit-item-details-layer-vector.js
@@ -27,6 +27,18 @@ export default importComponents( [
                     } )
                 }
             },
+            showCoverageOnHover: {
+                get: function () {
+                    var layer = this.$store.getters.configLayer( this.itemId )
+                    return layer.clusterOption && !!layer.clusterOption.showCoverageOnHover
+                },
+                set: function ( val ) {
+                    var layer = this.$store.getters.configLayer( this.itemId )
+                    if ( !layer.clusterOption ) layer.clusterOption = {}
+                    layer.clusterOption.showCoverageOnHover = !!val
+                    this.$store.dispatch( 'configLayer', layer )
+                }
+            }
         },
         mounted: function () {
         },

--- a/smk-edit/static/components/edit-item.css
+++ b/smk-edit/static/components/edit-item.css
@@ -1,3 +1,6 @@
+.modal.edit-item .modal-content {
+    height: calc(100vh - 56px);
+}
 
 .edit-item .modal-content {
     display: flex;

--- a/smk-edit/static/components/edit-item.css
+++ b/smk-edit/static/components/edit-item.css
@@ -1,6 +1,3 @@
-.modal.edit-item .modal-content {
-    height: calc(100vh - 56px);
-}
 
 .edit-item .modal-content {
     display: flex;


### PR DESCRIPTION
This adds the ability to toggle the "showCoverageOnHover" property on a vector layer.

package.json is updated to require smk version 1.0.6 or greater as the ability to read the showCoverageOnHover property in a vector layer was added in that version.

Docs are updated to reflect UI changes as well as make text more consistent.