### PR TITLE
Geomark updates

### DIFF
--- a/docs/edit-tool.md
+++ b/docs/edit-tool.md
@@ -159,10 +159,6 @@ In Addtional to the default settings for a tool, you can specify the following o
 
 The Geomark tool allows creating and loading geomarks. A geomark is an area of interest that is stored in a web service and can be shared by a URL. A geomark can be created in SMK by drawing one or more shapes and saving the drawing as a geomark. A geomark can also be loaded by its URL.
 
-### Geomark Service URL
-
-`Geomark Service URL` is the address of the Geomark web service used. The production service URL is used as a default, but a user may specify an alternative service URL.
-
 ### Enable Link to Create a Geomark from a File
 
 When checked, `Enable Link to Create a Geomark from a File` will add an option to the panel that opens a browser tab to the page of the geomark web service where a file can be uploaded to create a new geomark. The geomark's URL can then be used to load a geomark in SMK. This is an alternative to drawing a shape in SMK and saving it as a geomark.

--- a/smk-create/template-mobile/resources/smk-config.json
+++ b/smk-create/template-mobile/resources/smk-config.json
@@ -131,7 +131,7 @@
             },
             "enableCreateFromFile": false,
             "position": "list-menu",
-            "enabled": <%= !!app.tool.geomark %>
+            "enabled": false
         }
     ]
 }

--- a/smk-edit/static/components/edit-tool-details-geomark.html
+++ b/smk-edit/static/components/edit-tool-details-geomark.html
@@ -5,13 +5,6 @@
     ></edit-tool-details>
 
     <div class="row">
-        <div class="col" style="float:none">
-            <input-text
-                v-model="geomarkServiceUrl"
-            >Geomark service URL</input-text>
-        </div>
-    </div>
-    <div class="row">
         <input-checkbox class="col s6"
             v-model="enableCreateFromFile"
         >Enable option to create a geomark from a file</input-checkbox>

--- a/smk-edit/static/components/edit-tool-details-geomark.js
+++ b/smk-edit/static/components/edit-tool-details-geomark.js
@@ -6,14 +6,6 @@ export default importComponents( [
     return vueComponent( import.meta.url, {
         props: [ 'toolType', 'toolInstance' ],
         computed: {
-            geomarkServiceUrl: {
-                get: function () {
-                    return this.$store.getters.configTool( this.toolType, this.toolInstance ).geomarkService.url
-                },
-                set: function ( val ) {
-                    this.$store.dispatch( 'configToolSubProp', { type: this.toolType, instance: this.toolInstance, propName: 'geomarkService', url: val } )
-                }
-            },
             enableCreateFromFile: {
                 get: function () {
                     return this.$store.getters.configTool( this.toolType, this.toolInstance ).enableCreateFromFile

--- a/smk-edit/static/store/config-tool-geomark.js
+++ b/smk-edit/static/store/config-tool-geomark.js
@@ -5,9 +5,6 @@ export default {
                 return Object.assign( {
                     title: 'Geomark',
                     order: 3,
-                    geomarkService: {
-                        url: 'https://apps.gov.bc.ca/pub/geomark'
-                    },
                     enableCreateFromFile: false
                 }, tool )
             },


### PR DESCRIPTION
- The geomark tool is disabled in mobile configuration
- The 'Geomark URL' property is removed from smk-edit docs, the tool editor panel and script, and the configuration store