### PR TITLE
Pin Vuex version at the latest version compatible with Vue 2: 3.6.2.

### DIFF
--- a/smk-edit/static/index.html
+++ b/smk-edit/static/index.html
@@ -29,7 +29,7 @@
         <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
 
         <!-- VueX -->
-        <script src="https://unpkg.com/vuex"></script>
+        <script src="https://unpkg.com/vuex@3.6.2"></script>
 
         <!-- Spectrum -->
         <script src="https://cdnjs.cloudflare.com/ajax/libs/spectrum/1.8.1/spectrum.min.js"></script>


### PR DESCRIPTION
The SMK CLI uses Vue 2 which is only compatible with Vuex 3.X. The smk-cli editor app is currently broken because it downloads the latest version of Vuex which is v 4.x.

We need to pin the Vuex version to a Vuex 3.X release.