### PR TITLE
MPCM layers can show labels

### DIFF
--- a/smk-edit/static/components/edit-item-details-layer-esri-dynamic.html
+++ b/smk-edit/static/components/edit-item-details-layer-esri-dynamic.html
@@ -5,4 +5,11 @@
             <label for="dbcDefinitionExpression">Dynamic Expression</label>
         </div>
     </div>-->
+    <div class="row">
+        <input-checkbox 
+            class="col s12"
+            v-if="hasLabels"
+            v-model="showLabels"
+        >Show labels</input-checkbox>
+    </div>
 </div>

--- a/smk-edit/static/components/edit-item-details-layer-esri-dynamic.js
+++ b/smk-edit/static/components/edit-item-details-layer-esri-dynamic.js
@@ -7,7 +7,7 @@ export default importComponents( [
         computed: {
             hasLabels: function() {
                 const layer = this.$store.getters.configLayer( this.itemId );
-                if (layer.dynamicLayers) {
+                if (layer && layer.dynamicLayers) {
                     for (const dynamicLayer of layer.dynamicLayers) {
                         const dynamicJson = JSON.parse(dynamicLayer);
                         if(dynamicJson.drawingInfo && dynamicJson.drawingInfo.labelingInfo) {
@@ -20,7 +20,7 @@ export default importComponents( [
             showLabels: {
                 get: function () {
                     const layer = this.$store.getters.configLayer( this.itemId );
-                    if (layer.dynamicLayers) {
+                    if (layer && layer.dynamicLayers) {
                         for (const dynamicLayer of layer.dynamicLayers) {
                             const dynamicJson = JSON.parse(dynamicLayer);
                             if(dynamicJson.drawingInfo 
@@ -34,7 +34,7 @@ export default importComponents( [
                 },
                 set: function ( val ) {
                     const layer = this.$store.getters.configLayer( this.itemId );
-                    if (layer.dynamicLayers) {
+                    if (layer && layer.dynamicLayers) {
                         for (let i = 0; i < layer.dynamicLayers.length; i++) {
                             const dynamicJson = JSON.parse(layer.dynamicLayers[i]);
                             if(dynamicJson.drawingInfo && dynamicJson.drawingInfo.labelingInfo) {

--- a/smk-edit/static/components/edit-item-details-layer-esri-dynamic.js
+++ b/smk-edit/static/components/edit-item-details-layer-esri-dynamic.js
@@ -4,6 +4,47 @@ export default importComponents( [
 ] ).then( function () {
     return vueComponent( import.meta.url, {
         props: [ 'itemId' ],
+        computed: {
+            hasLabels: function() {
+                const layer = this.$store.getters.configLayer( this.itemId );
+                if (layer.dynamicLayers) {
+                    for (const dynamicLayer of layer.dynamicLayers) {
+                        let dynamicJson = JSON.parse(dynamicLayer);
+                        if(dynamicJson.drawingInfo.labelingInfo) {
+                            return true;
+                        }
+                    };
+                }
+                return false;
+            },
+            showLabels: {
+                get: function () {
+                    const layer = this.$store.getters.configLayer( this.itemId );
+                    if (layer.dynamicLayers) {
+                        for (const dynamicLayer of layer.dynamicLayers) {
+                            const dynamicJson = JSON.parse(dynamicLayer);
+                            if(dynamicJson.drawingInfo.labelingInfo && dynamicJson.drawingInfo.showLabels) {
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
+                },
+                set: function ( val ) {
+                    let layer = this.$store.getters.configLayer( this.itemId );
+                    if (layer.dynamicLayers) {
+                        for (let i = 0; i < layer.dynamicLayers.length; i++) {
+                            const dynamicJson = JSON.parse(layer.dynamicLayers[i]);
+                            if(dynamicJson.drawingInfo.labelingInfo) {
+                                dynamicJson.drawingInfo.showLabels = val;
+                                layer.dynamicLayers[i] = JSON.stringify(dynamicJson);
+                            }
+                        }
+                        this.$store.dispatch( 'configLayer', layer );
+                    }
+                }
+            }
+        },
         mounted: function () {
         },
         updated: function () {

--- a/smk-edit/static/components/edit-item-details-layer-esri-dynamic.js
+++ b/smk-edit/static/components/edit-item-details-layer-esri-dynamic.js
@@ -9,8 +9,8 @@ export default importComponents( [
                 const layer = this.$store.getters.configLayer( this.itemId );
                 if (layer.dynamicLayers) {
                     for (const dynamicLayer of layer.dynamicLayers) {
-                        let dynamicJson = JSON.parse(dynamicLayer);
-                        if(dynamicJson.drawingInfo.labelingInfo) {
+                        const dynamicJson = JSON.parse(dynamicLayer);
+                        if(dynamicJson.drawingInfo && dynamicJson.drawingInfo.labelingInfo) {
                             return true;
                         }
                     };
@@ -23,19 +23,21 @@ export default importComponents( [
                     if (layer.dynamicLayers) {
                         for (const dynamicLayer of layer.dynamicLayers) {
                             const dynamicJson = JSON.parse(dynamicLayer);
-                            if(dynamicJson.drawingInfo.labelingInfo && dynamicJson.drawingInfo.showLabels) {
-                                return true;
+                            if(dynamicJson.drawingInfo 
+                                && dynamicJson.drawingInfo.labelingInfo 
+                                && dynamicJson.drawingInfo.showLabels) {
+                                    return true;
                             }
                         }
                     }
                     return false;
                 },
                 set: function ( val ) {
-                    let layer = this.$store.getters.configLayer( this.itemId );
+                    const layer = this.$store.getters.configLayer( this.itemId );
                     if (layer.dynamicLayers) {
                         for (let i = 0; i < layer.dynamicLayers.length; i++) {
                             const dynamicJson = JSON.parse(layer.dynamicLayers[i]);
-                            if(dynamicJson.drawingInfo.labelingInfo) {
+                            if(dynamicJson.drawingInfo && dynamicJson.drawingInfo.labelingInfo) {
                                 dynamicJson.drawingInfo.showLabels = val;
                                 layer.dynamicLayers[i] = JSON.stringify(dynamicJson);
                             }

--- a/smk-edit/static/store/config-tool-layers.js
+++ b/smk-edit/static/store/config-tool-layers.js
@@ -131,6 +131,9 @@ export default {
 
             if ( context.getters.configHasLayer( itemId ) )
                 context.dispatch( 'configLayerRemove', { id: itemId } )
+        },
+        configToolLayersDisplayToggleLabelVisibility( context, itemId ) {
+            var item = context.getters.configToolLayersDisplayItem( itemId );
         }
     },
 }

--- a/smk-edit/static/store/config-tool-layers.js
+++ b/smk-edit/static/store/config-tool-layers.js
@@ -131,9 +131,6 @@ export default {
 
             if ( context.getters.configHasLayer( itemId ) )
                 context.dispatch( 'configLayerRemove', { id: itemId } )
-        },
-        configToolLayersDisplayToggleLabelVisibility( context, itemId ) {
-            var item = context.getters.configToolLayersDisplayItem( itemId );
         }
     },
 }


### PR DESCRIPTION
This updates the layer editor for MPCM layers. When an MPCM layer has a non-empty "labelingInfo" value, we add a checkbox to show label information. This then sets the value of the "showLabels" property of the "drawingInfo" property of dynamic layers in smk-config.json.