### PR TITLE
xmldom updated for vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@bcgov/smk": ">=1.1.0",
         "@tmcw/togeojson": "~4.5.0",
-        "@xmldom/xmldom": "~0.8.3",
+        "@xmldom/xmldom": "~0.8.5",
         "chalk": "~4.1.0",
         "cors": "~2.8.5",
         "csv-parse": "~4.16.0",
@@ -56,9 +56,9 @@
       "integrity": "sha512-lNuuhW7nvN1T7xII9eRTi9zuPwYfFl43/1u/Xgi88tedX4ePfwJB5dqc31N7z6sWeR+7EES274ESNrK1gsW53A=="
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.3.tgz",
-      "integrity": "sha512-Lv2vySXypg4nfa51LY1nU8yDAGo/5YwF+EY/rUZgIbfvwVARcd67ttCM8SMsTeJy51YhHYavEq+FS6R0hW9PFQ==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.5.tgz",
+      "integrity": "sha512-0dpjDLeCXYThL2YhqZcd/spuwoH+dmnFoND9ZxZkAYxp1IJUB2GP16ow2MJRsjVxy8j1Qv8BJRmN5GKnbDKCmQ==",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -3164,9 +3164,9 @@
       "integrity": "sha512-lNuuhW7nvN1T7xII9eRTi9zuPwYfFl43/1u/Xgi88tedX4ePfwJB5dqc31N7z6sWeR+7EES274ESNrK1gsW53A=="
     },
     "@xmldom/xmldom": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.3.tgz",
-      "integrity": "sha512-Lv2vySXypg4nfa51LY1nU8yDAGo/5YwF+EY/rUZgIbfvwVARcd67ttCM8SMsTeJy51YhHYavEq+FS6R0hW9PFQ=="
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.5.tgz",
+      "integrity": "sha512-0dpjDLeCXYThL2YhqZcd/spuwoH+dmnFoND9ZxZkAYxp1IJUB2GP16ow2MJRsjVxy8j1Qv8BJRmN5GKnbDKCmQ=="
     },
     "abbrev": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "touch": "~3.1.0",
     "unzipper": "~0.10.11",
     "xml2js": "~0.4.23",
-    "@xmldom/xmldom": "~0.8.3"
+    "@xmldom/xmldom": "~0.8.5"
   },
   "devDependencies": {
     "connect-livereload": "~0.6.0",


### PR DESCRIPTION
@xmldom/xmldom is updated to the latest version to address a security vulnerability: https://github.com/advisories/GHSA-crh6-fp67-6883.

xmldom is used in converters.js for parsing KML. I don’t think the risk is high enough to warrant a release.