### PR TITLE
Remove Measure tool from create

### DIFF
--- a/docs/create-an-app.md
+++ b/docs/create-an-app.md
@@ -116,7 +116,6 @@ Press your arrow direction buttons up or down to choose an option, and press ent
 - layers
 - pan
 - zoom
-- measure
 - markup
 - minimap
 - identify

--- a/docs/edit-tool.md
+++ b/docs/edit-tool.md
@@ -253,6 +253,8 @@ List menu allows you to modify the common settings for tools only.
 
 ## Measure
 
+**Deprecated** - This tool does not work properly in SMK versions 1.1.2 and later. 
+
 The Measure tool adds a measure utility to your application that allows users to make distance and area measurements on your map. See the [SMK Documentation](https://bcgov.github.io/smk/) for more details.
 
 Measure tool allows you to modify the common settings for tools only.

--- a/smk-create/index.js
+++ b/smk-create/index.js
@@ -170,7 +170,7 @@ async function inquireAppInfo( name, baseDir, package, version ) {
             name: 'tools',
             type: 'checkbox',
             message: 'Select the tools:',
-            choices: [ 'about', 'coordinate', 'layers', 'pan', 'zoom', 'measure', 'markup', 'scale', 'minimap', 'directions', 'location', 'select', 'identify', 'search', 'geomark' ],
+            choices: [ 'about', 'coordinate', 'layers', 'pan', 'zoom', 'markup', 'scale', 'minimap', 'directions', 'location', 'select', 'identify', 'search', 'geomark' ],
             default: [ 'about', 'coordinate', 'layers', 'pan', 'zoom', 'scale', 'minimap', 'identify', 'search' ]
         }
     ] )

--- a/smk-create/template-default/resources/smk-config.json
+++ b/smk-create/template-default/resources/smk-config.json
@@ -86,10 +86,6 @@
             "enabled": <%= !!app.tool.coordinate %>
         },
         {
-            "type": "measure",
-            "enabled": <%= !!app.tool.measure %>
-        },
-        {
             "type": "markup",
             "enabled": <%= !!app.tool.markup %>
         },

--- a/smk-create/template-mobile/resources/smk-config.json
+++ b/smk-create/template-mobile/resources/smk-config.json
@@ -95,11 +95,6 @@
             "enabled": false
         },
         {
-            "type": "measure",
-            "enabled": <%= !!app.tool.measure %>,
-            "position": "list-menu"
-        },
-        {
             "type": "markup",
             "enabled": false
         },


### PR DESCRIPTION
The leaflet-measure library, which the Measure tool is built around, stopped working properly when the leaflet library was updated in SMK 1.1.2. This change prevents enabling the Measure tool when creating an SMK app. It also updates documentation to show that it is deprecated.