### PR TITLE
Minimap no longer default when creating

### DIFF
--- a/smk-create/index.js
+++ b/smk-create/index.js
@@ -171,7 +171,7 @@ async function inquireAppInfo( name, baseDir, package, version ) {
             type: 'checkbox',
             message: 'Select the tools:',
             choices: [ 'about', 'coordinate', 'layers', 'pan', 'zoom', 'measure', 'markup', 'scale', 'minimap', 'directions', 'location', 'select', 'identify', 'search', 'geomark' ],
-            default: [ 'about', 'coordinate', 'layers', 'pan', 'zoom', 'scale', 'minimap', 'identify', 'search' ]
+            default: [ 'about', 'coordinate', 'layers', 'pan', 'zoom', 'scale', 'identify', 'search' ]
         }
     ] )
 }


### PR DESCRIPTION
This addresses a bug where creating a new SMK app and specifying the Stamen Toner Light (non-Esri) base map results in an alert saying the Esri API key is missing when the app is loaded. This happens because the Minimap tool uses the Topographic basemap, which uses Esri API.