### PR TITLE
StamenTonerLight replaced by BC Gov basemaps

### DIFF
--- a/docs/create-an-app.md
+++ b/docs/create-an-app.md
@@ -18,7 +18,7 @@ which will return the available commands that the SMK-CLI supports.
 /\__/ /| || | | | | || |_) || ||  __/ | |  | || (_| || |_) | | |\  \| || |_
 \____/ |_||_| |_| |_|| .__/ |_| \___| \_|  |_/ \__,_|| .__/  \_| \_/|_| \__|
                      | |                             | |
-                     |_|                             |_|   CLI v1.1.0
+                     |_|                             |_|   CLI v1.2.0
 Usage: index create|edit|help
 To create a new SMK project:     index create [name]
 To modify an SMK project config: index edit [-p port]
@@ -55,7 +55,7 @@ Where `mySmkProject` will be your desired project name. You will then be present
   /  \ |   / |/ |/ |    |/ \_ |/   |/      |  |  |   /  |    |/ \_    | \    |    |
  /(__/ |_/   |  |  |_/  |__/  |__/ |__/    |  |  |_/ \_/|_/  |__/     |  \_/ |_/  |_/
                        /|                                   /|
-                       \|                                   \|      CLI v1.1.0
+                       \|                                   \|      CLI v1.2.0
 Welcome to the SMK application creation tool!
 An application skeleton will be created for you at the current directory.
 But first, please answer some questions about your new SMK application.
@@ -65,10 +65,10 @@ But first, please answer some questions about your new SMK application.
 ? Enter a short description for your application: This is a really cool map
 ? Enter the author's name: Vivid Solutions Inc.
 ? Enter the package name of SMK: smk
-? Select the version of smk for your application: 1.1.0
+? Select the version of smk for your application: 1.2.0
 ? Select the template for your application: default
 ? Select the type of map viewer: leaflet
-? Select the base map: Topographic
+? Select the base map: BCGov
 ? Enter an Esri API key: my-Esri-API-key
 ? Select the tools: about, coordinate, layers, pan, zoom, scale, minimap, identify, search
 ```
@@ -106,7 +106,7 @@ SMK also uses:
 - BCGov
 - BCGovHillshade
 
-Press your arrow direction buttons up or down to choose an option, and press enter to select it. The default is `Topographic`.
+Press your arrow direction buttons up or down to choose an option, and press enter to select it. The default is `BCGov`.
 
 `Enter an Esri API key` Several basemaps are provided by Esri and require the use of an API key. To get an API key, create an [ArcGIS Developer account](https://developers.arcgis.com/sign-up/) or [ArcGIS Online account](https://www.esri.com/en-us/arcgis/products/arcgis-online/trial) and then create an [API key](https://developers.arcgis.com/documentation/mapping-apis-and-services/security/api-keys/) in the [developer dashboard](https://developers.arcgis.com/dashboard/).
 

--- a/docs/create-an-app.md
+++ b/docs/create-an-app.md
@@ -103,7 +103,8 @@ Note: Currently Esri 3D support is experimental.
 
 SMK also uses:
 
-- StamenTonerLight
+- BCGov
+- BCGovHillshade
 
 Press your arrow direction buttons up or down to choose an option, and press enter to select it. The default is `Topographic`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bcgov/smk-cli",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bcgov/smk-cli",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@bcgov/smk": ">=1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
-        "@bcgov/smk": ">=1.1.0",
+        "@bcgov/smk": ">=1.2.0",
         "@tmcw/togeojson": "~4.5.0",
         "@xmldom/xmldom": "~0.8.5",
         "chalk": "~4.1.0",
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@bcgov/smk": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@bcgov/smk/-/smk-1.1.0.tgz",
-      "integrity": "sha512-fkStwRW9TI3/J6qTwyxIGizoj2imjDP8gYO0eP7z10bGP5aOk+OECAt8vV+83MGHsMpYswK8wdtN6iGgBJcSiQ=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@bcgov/smk/-/smk-1.2.0.tgz",
+      "integrity": "sha512-cPj4V+I9sus2ETkKi9uAvvuS5jili8C2Gpa43jT+pMrJf4VC1vcmlwV3+QPLRDXE4IAzHrzPHrDuiIua6BkKzg=="
     },
     "node_modules/@tmcw/togeojson": {
       "version": "4.5.0",
@@ -3154,9 +3154,9 @@
   },
   "dependencies": {
     "@bcgov/smk": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@bcgov/smk/-/smk-1.1.0.tgz",
-      "integrity": "sha512-fkStwRW9TI3/J6qTwyxIGizoj2imjDP8gYO0eP7z10bGP5aOk+OECAt8vV+83MGHsMpYswK8wdtN6iGgBJcSiQ=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@bcgov/smk/-/smk-1.2.0.tgz",
+      "integrity": "sha512-cPj4V+I9sus2ETkKi9uAvvuS5jili8C2Gpa43jT+pMrJf4VC1vcmlwV3+QPLRDXE4IAzHrzPHrDuiIua6BkKzg=="
     },
     "@tmcw/togeojson": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/smk-cli",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A utility for creating and configuring a Simple Map Kit project",
   "main": "index.js",
   "author": "Ben Jubb <benjubb@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "debug": "./index.js edit --open no --base build/test-app --ping 300000"
   },
   "dependencies": {
-    "@bcgov/smk": ">=1.1.0",
+    "@bcgov/smk": ">=1.2.0",
     "@tmcw/togeojson": "~4.5.0",
     "chalk": "~4.1.0",
     "cors": "~2.8.5",

--- a/smk-create/index.js
+++ b/smk-create/index.js
@@ -135,7 +135,7 @@ async function inquireAppInfo( name, baseDir, package, version ) {
             },
             choices: function ( app ) {
                 const allVersions = JSON.parse( shell.exec( `npm view ${ app.smkPackage } versions --json`, { silent: true } ).stdout )
-                const supportedVersions = allVersions.filter(version => semverGte(version, '1.1.0'))
+                const supportedVersions = allVersions.filter(version => semverGte(version, '1.2.0'))
                 return semverRsort( supportedVersions )
             }
         },
@@ -157,14 +157,14 @@ async function inquireAppInfo( name, baseDir, package, version ) {
             name: 'baseMap',
             type: 'list',
             message: 'Select the base map:',
-            choices: [ 'Topographic', 'Streets', 'Imagery', 'Oceans', 'ShadedRelief', 'DarkGray', 'Gray', 'StamenTonerLight' ],
-            default: 'Topographic'
+            choices: [ 'BCGov', 'BCGovHillshade', 'Topographic', 'Streets', 'Imagery', 'Oceans', 'ShadedRelief', 'DarkGray', 'Gray' ],
+            default: 'BCGov'
         },
         {
             name: 'esriApiKey',
             type: 'input',
             message: 'Enter an Esri API key:',
-            when: answers => !['StamenTonerLight'].includes(answers.baseMap)
+            when: answers => !['BCGov', 'BCGovHillshade'].includes(answers.baseMap)
         },
         {
             name: 'tools',

--- a/smk-edit/static/components/edit-item.js
+++ b/smk-edit/static/components/edit-item.js
@@ -66,7 +66,7 @@ export default importComponents( [
                     'show-tool=pan,zoom,toolbar,layers,identify,scale,coordinate,baseMaps,legend',
                     {
                         viewer: {
-                            baseMap: 'StamenTonerLight'
+                            baseMap: 'BCGov'
                         },
                         layers: [
                             this.$store.getters.configLayer( this.itemId )

--- a/smk-edit/static/components/presentation.js
+++ b/smk-edit/static/components/presentation.js
@@ -209,6 +209,16 @@ export const availableTools = Object.keys( toolTypePresentation )
 
 export const baseMaps = [
     {
+        id: 'BCGov',
+        title: 'BC Government',
+        type: 'Open'
+    },
+    {
+        id: 'BCGovHillshade',
+        title: 'BC Government Hillshade',
+        type: 'Open'
+    },
+    {
         id: 'Topographic',
         title: 'Topographic',
         type: 'ESRI'
@@ -242,11 +252,6 @@ export const baseMaps = [
         id: 'Gray',
         title: 'Gray',
         type: 'ESRI'
-    },
-    {
-        id: 'StamenTonerLight',
-        title: 'Stamen Toner Light',
-        type: 'Open'
     }
 ]
 

--- a/smk-edit/static/store/config-viewer.js
+++ b/smk-edit/static/store/config-viewer.js
@@ -26,7 +26,7 @@ export default {
             return state.device || 'auto'
         },
         configViewerBaseMap: function ( state ) {
-            return state.baseMap || 'Topographic'
+            return state.baseMap || 'BCGov'
         },
         configViewerEsriApiKey: function ( state ) {
             return state.esriApiKey


### PR DESCRIPTION
This complements changes in https://github.com/bcgov/smk/pull/236. Again, the basemap name may change, but almost all the functionality is in this change. (TODO: update package.json to require SMK minimum version 1.2.0 - this needs to wait for SMK 1.2.0 to be released.)