### PR TITLE
WMS catalog URLs use ows path (MAP-8996)

### DIFF
--- a/docs/edit-an-app.md
+++ b/docs/edit-an-app.md
@@ -178,15 +178,15 @@ The functionality for WMS layers is identical to that of the DataBC layers descr
 
 #### Setting your WMS URL
 
-By default, the application will set the WMS service URL to the [DataBC Catalog WMS Service](https://openmaps.gov.bc.ca/geo/pub/wms). To change your WMS service, click once on the WMS Selector.
+By default, the application will set the WMS service URL to the [DataBC Catalog WMS Service](https://openmaps.gov.bc.ca/geo/pub/ows). To change your WMS service, click once on the WMS Selector.
 
 ![WMS Selector](smk-cli-wms-selector.png)
 
 You'll notice that the selector is actually a dropdown select box. SMK-CLI is pre-configured with some additional default WMS Services. These include:
 
-- [DataBC Catalog WMS Service](https://openmaps.gov.bc.ca/geo/pub/wms) (selected by default)
+- [DataBC Catalog WMS Service](https://openmaps.gov.bc.ca/geo/pub/ows) (selected by default)
 - [Maps.th.gov.bc.ca](https://maps.th.gov.bc.ca/geoV05/ows)
-- [NRS GeoServer](https://geo.nrs.gov.bc.ca/pub/geoserver/wms)
+- [NRS GeoServer](https://geo.nrs.gov.bc.ca/pub/geoserver/ows)
 - Another WMS Service
 
 ![Selector](smk-cli-wms-selector.png)

--- a/smk-edit/static/store.js
+++ b/smk-edit/static/store.js
@@ -11,11 +11,11 @@ export const store = new Vuex.Store( {
         statusPingInterval: 5000,
         dirtyConfig: false,
         activeTab: null,
-        wmsCatalogUrl: 'https://openmaps.gov.bc.ca/geo/pub/wms',
+        wmsCatalogUrl: 'https://openmaps.gov.bc.ca/geo/pub/ows',
         wmsCatalogUrls: [
-            'https://openmaps.gov.bc.ca/geo/pub/wms',
+            'https://openmaps.gov.bc.ca/geo/pub/ows',
             'https://maps.th.gov.bc.ca/geoV05/ows',
-            'https://geo.nrs.gov.bc.ca/pub/geoserver/wms'
+            'https://geo.nrs.gov.bc.ca/pub/geoserver/ows'
         ],
         version: 1,
         smkUrl: '/module/smk.js'


### PR DESCRIPTION
This fixes failing WFS requests for WMS layers. A /wms path supports WMS requests but may not support WFS requests, whereas an /ows path supports WMS, WFS, and other request types depending on the configuration of the server.